### PR TITLE
Updated docs.json to fix broken link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -86,7 +86,7 @@
           "text": "Get familiar with the key concepts behind EOSIO, learn about the core stack, and what it can do for your project ",
           "button": {
             "text": "Learn EOSIO",
-            "link": "/"
+            "link": "/overview"
           }
         },
         {


### PR DESCRIPTION
Resolves #9 

The **Learn More** button on the home page was not configured. Therefore, updated the link with `/overview`.