### PR TITLE
Updated the callout syntax [For Issue # 11]

### DIFF
--- a/docs/01_overview/01_platform_and_toolchain.md
+++ b/docs/01_overview/01_platform_and_toolchain.md
@@ -14,7 +14,7 @@ The basic relationship between these components is illustrated in the following 
 ![EOSIO Development Lifecycle](../images/EOSIO-Overview-dev.svg)
 
 
-[[ info | Note ]]
+[[info | Note]]
 | EOSIO also provides a frontend library for javascript development called EOSJS along with Swift and Java SDKs for native mobile applications development.
 
 ## Nodeos


### PR DESCRIPTION
Resolves #11 

There is a callout syntax error in the Note that talks about the availability of eosjs and SDKs. The Note is not rendering due to incorrect callout syntax. Corrected the syntax and submitting PR.

Please review if the correct syntax is updated. 