### PR TITLE
Fixed volatile links for core concepts

### DIFF
--- a/docs/01_overview/02_core_concepts.md
+++ b/docs/01_overview/02_core_concepts.md
@@ -13,7 +13,7 @@ Wallets are clients that store keys that may or may not be associated with the p
 
 Permissions are arbitrary names used to define the requirements for a transaction sent on behalf of that permission. Permissions can be assigned for authority over specific contract actions by *linking authorization* or linkauth.
 
-For more information about these concepts, see the _Accounts and Permissions_ documentation.
+For more information about these concepts, see the [_Accounts and Permissions_](http://developers.eos.io/protocol/accounts_and_permissions) documentation.
 <!-- The link will be updated once the initial site is live -->
 
 ### Smart Contracts
@@ -27,7 +27,7 @@ A smart contract is a piece of code that can execute on a blockchain and keep th
 
 The EOSIO platform implements a proven decentralized consensus algorithm capable of meeting the performance requirements of applications on the blockchain called the _Delegated Proof of Stake_ (DPOS). Under this algorithm, if you hold tokens on a EOSIO-based blockchain, you can select block producers through a continuous approval voting system. Anyone can choose to participate in the block production and will be given an opportunity to produce blocks, provided they can persuade token holders to vote for them.
 
-For more information about DPOS BFT, see [EOSIO Consensus](https://github.com/EOSIO/documentation-root/blob/master/docs/04_protocol/01_core/01_consensus_protocol.md#3-eosio-consensus-dpos--abft).
+For more information about DPOS BFT, see [EOSIO Consensus](http://developers.eos.io/protocol/consensus_protocol/#3-eosio-consensus-dpos--abft).
 
 <!-- The link will be updated once the initial site is live -->
 
@@ -37,18 +37,18 @@ For more information about DPOS BFT, see [EOSIO Consensus](https://github.com/EO
 
 RAM, in a EOSIO-based blockchain, is one of the important system resources consumed by blockchain accounts and smart contracts. RAM acts as a permanent storage and is used to store account names, permissions, token balance and other data for speedy on-chain data access. RAM needs to be purchased and is not based on staking as it is a limited persistent resource.
 
-More details about RAM as a system resource can be found [here](https://github.com/EOSIO/eosio.contracts/blob/docs/split_index_md/docs/01_core_concepts/02_ram.md).
+More details about RAM as a system resource can be found [here](http://developers.eos.io/manuals/eosio.contracts/latest/index/#ram).
 
 
 ### CPU
 
 CPU, in a EOSIO-based blockchain, represents the processing time of an action and is measured in microseconds (μs). CPU is referred to as `cpu bandwidth` in the cleos `get account` command output and indicates the amount of processing time an account has at its disposal when pushing actions to a contract. CPU is a transient system resource and falls under the staking mechanism of EOSIO.
 
-More details about CPU as a system resource can be found [here](https://github.com/EOSIO/eosio.contracts/blob/docs/split_index_md/docs/01_core_concepts/02_cpu.md).
+More details about CPU as a system resource can be found [here](http://developers.eos.io/manuals/eosio.contracts/latest/index/#cpu).
 
 
 ### Network (NET)
 Besides CPU and RAM, NET is also a very important resource in EOSIO-based blockchains. NET is the network bandwidth, measured in bytes, of transactions and is referred to as `net bandwidth` on the cleos `get account` command. NET is a also a transient system resource and falls under the staking mechanism of EOSIO.
 
-More details about NET as a system resource can be found [here](https://github.com/EOSIO/eosio.contracts/blob/docs/split_index_md/docs/01_core_concepts/04_net.md).
+More details about NET as a system resource can be found [here](http://developers.eos.io/manuals/eosio.contracts/latest/index/#net).
 


### PR DESCRIPTION
Resolves #10 

Please review the links:

For **RAM**:
http://developers.eos.io/manuals/eosio.contracts/latest/index/#ram

For **CPU**:
http://developers.eos.io/manuals/eosio.contracts/latest/index/#cpu

For **NET**:
http://developers.eos.io/manuals/eosio.contracts/latest/index/#net

For **EOSIO Consensus**
http://developers.eos.io/protocol/consensus_protocol/#3-eosio-consensus-dpos--abft

For **Accounts and Permissions**:
http://developers.eos.io/protocol/accounts_and_permissions


I am not sure if we should use `latest` or the `version no` like mentioned in Issue #10 

@dskvr: Could you review and let me know if these are correct links?
