### PR TITLE
Bugfix/badly formatted links

### DIFF
--- a/docs/01_overview/01_platform_and_toolchain.md
+++ b/docs/01_overview/01_platform_and_toolchain.md
@@ -21,14 +21,14 @@ The basic relationship between these components is illustrated in the following 
 
 Nodeos is the core EOSIO node daemon. Nodeos handles the blockchain data persistence layer, peer-to-peer networking, and contract code scheduling. For development environments, nodeos enables you to set up a single node blockchain network. Nodeos offers a wide range of features through plugins which can be enabled or disabled at start time via the command line parameters or configuration files.
 
-You can read detailed documentation about `nodeos` [here](example.iohttps://developers.eos.io/manuals/eosio/nodeos/).
+You can read detailed documentation about `nodeos` [here](https://developers.eos.io/manuals/eosio/nodeos/latest/index).
 <!-- The link will be updated once the initial site is live -->
 
 ## Cleos
 
 `cleos` is a command line tool that interfaces with the REST APIs exposed by `nodeos`. You can also use `cleos` to deploy and test EOSIO smart contracts.
 
-You can read detailed documentation about `cleos` [here](example.iohttps://developers.eos.io/manuals/eosio/cleos/).
+You can read detailed documentation about `cleos` [here](https://developers.eos.io/manuals/eosio/latest/cleos/index).
 <!-- The link will be updated once the initial site is live -->
 
 ## Keosd
@@ -39,7 +39,7 @@ You can read detailed documentation about `cleos` [here](example.iohttps://devel
 [[ info | Note ]]
 | `keosd` can be accessed using the wallet API, but it is important to note that the intended usage is for local light client applications. `keosd` is not for cross network access by web applications trying to access users' wallets.
 
-You can read detailed documentation about `keosd` [here](example.iohttps://developers.eos.io/manuals/eosio/keosd/).
+You can read detailed documentation about `keosd` [here](https://developers.eos.io/manuals/eosio/latest/keosd/).
 <!-- The link will be updated once the initial site is live -->
 
 ## EOSIO.CDT

--- a/docs/01_overview/02_core_concepts.md
+++ b/docs/01_overview/02_core_concepts.md
@@ -13,7 +13,7 @@ Wallets are clients that store keys that may or may not be associated with the p
 
 Permissions are arbitrary names used to define the requirements for a transaction sent on behalf of that permission. Permissions can be assigned for authority over specific contract actions by *linking authorization* or linkauth.
 
-For more information about these concepts, see the [_Accounts and Permissions_](/protocol/accounts_and_permissions) documentation.
+For more information about these concepts, see the [_Accounts and Permissions_](../04_protocol/accounts_and_permissions) documentation.
 <!-- The link will be updated once the initial site is live -->
 
 ### Smart Contracts
@@ -27,7 +27,7 @@ A smart contract is a piece of code that can execute on a blockchain and keep th
 
 The EOSIO platform implements a proven decentralized consensus algorithm capable of meeting the performance requirements of applications on the blockchain called the _Delegated Proof of Stake_ (DPOS). Under this algorithm, if you hold tokens on a EOSIO-based blockchain, you can select block producers through a continuous approval voting system. Anyone can choose to participate in the block production and will be given an opportunity to produce blocks, provided they can persuade token holders to vote for them.
 
-For more information about DPOS BFT, see [EOSIO Consensus](/protocol/consensus_protocol/#3-eosio-consensus-dpos--abft).
+For more information about DPOS BFT, see [EOSIO Consensus](../04_protocol/01_consensus_protocol/#3-eosio-consensus-dpos--abft).
 
 <!-- The link will be updated once the initial site is live -->
 
@@ -51,4 +51,3 @@ More details about CPU as a system resource can be found [here](https://develope
 Besides CPU and RAM, NET is also a very important resource in EOSIO-based blockchains. NET is the network bandwidth, measured in bytes, of transactions and is referred to as `net bandwidth` on the cleos `get account` command. NET is a also a transient system resource and falls under the staking mechanism of EOSIO.
 
 More details about NET as a system resource can be found [here](https://developers.eos.io/manuals/eosio.contracts/latest/index/#net).
-

--- a/docs/02_getting-started/02_development-environment/07_create-test-accounts.md
+++ b/docs/02_getting-started/02_development-environment/07_create-test-accounts.md
@@ -81,4 +81,4 @@ Wallets:
 ```
 
 ## What's Next?
-- [Hello World](./04_smart-contract-development/01_hello-world.md): The Hello World of EOSIO! Learn how to set up your environment and deploy your first smart contract.
+- [Hello World](../03_smart-contract-development/01_hello-world.md): The Hello World of EOSIO! Learn how to set up your environment and deploy your first smart contract.

--- a/docs/02_getting-started/03_smart-contract-development/10_payable_actions.md
+++ b/docs/02_getting-started/03_smart-contract-development/10_payable_actions.md
@@ -139,7 +139,7 @@ The important thing to note is the deposit function will actually be triggered b
 ```cpp
 [[eosio::on_notify("eosio.token::transfer")]]
 ```
-The `on_notify` attribute is one of the EOSIO.CDT [attributes](/eosio.cdt/latest/best-practices/abi/abi-code-generator-attributes-explained) that annotates a smart contract action.
+The `on_notify` attribute is one of the EOSIO.CDT [attributes](https://developers.eos.io/manuals/eosio.cdt/latest/best-practices/abi/abi-code-generator-attributes-explained) that annotates a smart contract action.
 
 Annotating an action with an [`on_notify`](https://developers.eos.io/manuals/eosio.cdt/latest/best-practices/abi/abi-code-generator-attributes-explained/#eosioon_notifyvalid_eosio_account_namevalid_eosio_action_name) attribute ensures any incoming notification is forwarded to the annotated action if and only if the notification is dispatched from a specified contract and from a specified action.
 
@@ -310,4 +310,4 @@ Party time!
 
 
 ## What's Next?
-- [Elemental Battles](https://battles.eos.io): Build a blockchain game based on EOSIO and continue building your EOSIO knowledge! 
+- [Elemental Battles](https://battles.eos.io): Build a blockchain game based on EOSIO and continue building your EOSIO knowledge!

--- a/manuals-directory.yaml
+++ b/manuals-directory.yaml
@@ -10,7 +10,7 @@ sections:
         link: https://developers.eos.io/manuals/eos/latest/cleos
 
       - title: keosd
-        description: aA key manager service daemon for storing private keys and signing digital messages
+        description: A key manager service daemon for storing private keys and signing digital messages
         link: https://developers.eos.io/manuals/eos/latest/keosd
 
       - title: eosio.cdt


### PR DESCRIPTION
@bobgt Please review changes in this PR to understand the decisions made. When linking to markdown files in the same repo (child) just use relative paths. The relative paths **should resolve without generation!!!!** This is to make it easy on you, yes, when using the _infer navigation from filesystem_ method, which we are mostly using right now, that means you need to include the sort prefixes. 