### PR TITLE
Remove misuse of blockquotes, add new callout type that stands out less

### DIFF
--- a/docs/03_tutorials/bios-boot-sequence.md
+++ b/docs/03_tutorials/bios-boot-sequence.md
@@ -3,7 +3,8 @@ content_title: BIOS Boot Sequence
 link_text: BIOS Boot Sequence
 ---
 
-> _The steps here can be readily expanded for the networked case. Some assumptions are made here regarding how the parties involved will coordinate with each other. However, there are many ways that the community can choose to coordinate. The technical aspects of the process are objective; assumptions of how the coordination might occur are speculative. Several approaches have already been suggested by the community. You are encouraged to review the various approaches and get involved in the discussions as appropriate._
+[[note | Note]]
+| _The steps here can be readily expanded for the networked case. Some assumptions are made here regarding how the parties involved will coordinate with each other. However, there are many ways that the community can choose to coordinate. The technical aspects of the process are objective; assumptions of how the coordination might occur are speculative. Several approaches have already been suggested by the community. You are encouraged to review the various approaches and get involved in the discussions as appropriate._
 
 
 
@@ -475,10 +476,10 @@ executed transaction: a53961a566c1faa95531efb422cd952611b17d728edac833c9a5558242
 #   eosio.token <= eosio.token::issue           {"to":"eosio","quantity":"1000000000.0000 SYS","memo":"memo"}
 ```
 
----
-> _As a point of interest, from an economic point of view, moving token from reserve into circulation, such as by issuing tokens, is an inflationary action. Issuing tokens is just one way that inflation can occur._
 
----
+[[note | Note]]
+| _As a point of interest, from an economic point of view, moving token from reserve into circulation, such as by issuing tokens, is an inflationary action. Issuing tokens is just one way that inflation can occur._
+
 
 
 ### **1.12. Set the eosio.system contract**
@@ -624,7 +625,8 @@ To make the tutorial more realistic, we distribute the 1B tokens to accounts usi
 
 Use the following steps to stake tokens for each account. These steps must be done individually for each account.
 
-> _The key pair is created here for this tutorial. In a "live" scenario, the key value(s) and token share for an account should already be established through some well-defined out-of-band process._
+[[note | Note]]
+| _The key pair is created here for this tutorial. In a "live" scenario, the key value(s) and token share for an account should already be established through some well-defined out-of-band process._
 ```shell
 	$ cleos create key --to-console
 

--- a/docs/09_get-involved/index.md
+++ b/docs/09_get-involved/index.md
@@ -22,13 +22,16 @@ To make a quick edit:
 
 ![Fork the Repository](quick-edits-2.png)
 
-> If you are not signed in to your Github account, it will redirect you to the Github login page. Sign in with your username and password to continue. If you are new to Github, create a new account.
+[[note | Note]]
+| If you are not signed in to your Github account, it will redirect you to the Github login page. Sign in with your username and password to continue. If you are new to Github, create a new account.
 
 
 3. Make the suggested changes in the web editor using Markdown syntax. Click the **Preview changes** tab to see the preview of the content.
 4. After suggesting your changes, scroll down to the bottom on the page. Enter a title and a description of the changes you made and click **Propose file change**.
 5. Create a ***Pull Request*** by entering a title and a description. Click **Create pull request** to submit your suggestion to us.
-   > If you are new to Github, see [About Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) for more information.
+
+[[note | Note]]
+| If you are new to Github, see [About Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) for more information.
 
 Congrats! You have submitted your suggestion. Our team will review your pull request and merge it if it's a valid change.
 
@@ -43,9 +46,15 @@ To file a new issue:
 2. You will be directed to the Issues tab of the specific repository with an editable Issue form.
 
    ![New Issue Form](file-issues-2.png)
-   > If you are not signed in to your Github account, it will redirect you to the Github login page. Sign in with your username and password to continue. If you do not have a Github account, create a new account.
+
+[[note | Note]]
+| If you are not signed in to your Github account, it will redirect you to the Github login page. Sign in with your username and password to continue. If you do not have a Github account, create a new account.
+
 3. Enter the issue title and describe the issue with a proposed solution if you have using Markdown syntax.
-   > If you are filing an issue for the first time, review the contributing guidelines of the repository.
+
+[[note | Note]]
+| If you are filing an issue for the first time, review the contributing guidelines of the repository.
+
    ![Contribution Guidelines](file-issues-3.png)
 4. Click **Submit new issue** to submit the issue to the repository.
 


### PR DESCRIPTION
Blockquotes have a specific purpose @bobgt 
https://en.wikipedia.org/wiki/Blockquote_element

I anticipate this was because the current callout types stand out too much. Using an element that has a specific purpose and means a specific thing to search engines is not the solution. Voicing the problem is, so that a correct solution can be provided.

Made a new callout type "note" that has a light grey background and isn't as intrusive. 

Depends on https://github.com/EOSIO/eosio-docs-gatsby/pull/115