### PR TITLE
Updated headings in step 1 install binaries

### DIFF
--- a/docs/02_getting-started/02_development-environment/03_before-you-begin.md
+++ b/docs/02_getting-started/02_development-environment/03_before-you-begin.md
@@ -11,7 +11,7 @@ To get started as quickly as possible we recommend using pre-built binaries. Bui
 
 The below commands will download binaries for respective operating systems.
 
-## Mac OS X Brew Install:
+### Mac OS X Brew Install:
 ```shell
 brew tap eosio/eosio
 brew install eosio
@@ -20,17 +20,17 @@ brew install eosio
 [[info]]
 | If you don't have Brew installed, follow the installation instructions on the <a href="https://brew.sh/" target="_blank">official Brew website</a>.
 
-## Ubuntu 18.04 Debian Package Install:
+### Ubuntu 18.04 Debian Package Install:
 ```shell
 wget https://github.com/EOSIO/eos/releases/download/v1.8.6/eosio_1.8.6-1-ubuntu-18.04_amd64.deb
 sudo apt install ./eosio_1.8.6-1-ubuntu-18.04_amd64.deb
 ```
-## Ubuntu 16.04 Debian Package Install:
+### Ubuntu 16.04 Debian Package Install:
 ```shell
 wget https://github.com/EOSIO/eos/releases/download/v1.8.6/eosio_1.8.6-1-ubuntu-16.04_amd64.deb
 sudo apt install ./eosio_1.8.6-1-ubuntu-18.04_amd64.deb
 ```
-## CentOS RPM Package Install:
+### CentOS RPM Package Install:
 ```shell
 wget https://github.com/EOSIO/eos/releases/download/v1.8.6/eosio-1.8.6-1.el7.x86_64.rpm
 sudo yum install ./eosio-1.8.6-1.el7.x86_64.rpm


### PR DESCRIPTION
Currently, we are using heading 2 for **Step 1: Install binaries** and also heading 2 for the installation methods inside **Step 1: Install binaries**. To show the installation methods are sub headings of Step 1, we can use heading 3 for all installation methods. 

See attached screenshot for reference. 
<img width="260" alt="Screenshot 2020-01-29 at 10 25 30 PM" src="https://user-images.githubusercontent.com/36563110/73364919-5689bc80-42e6-11ea-85e8-64d587d4bc50.png">
