### PR TITLE
Updated image file name

### DIFF
--- a/docs/09_get-involved/index.md
+++ b/docs/09_get-involved/index.md
@@ -9,7 +9,7 @@ The following are different ways you can get involved with the EOSIO developers 
 
 For more information about the contribution guidelines of a particular repository, look for the "Contributing" link in the right-hand sidebar of the documentation.
 
-![Contributing link location](./contributing-link.png)
+![Contributing link location](./contributing-link-1.png)
 
 ### Developers Community Involvement
 


### PR DESCRIPTION
Resolves #139 

The image on the Get Involved page is not rendering due to incomplete file name. 

Updated the image file name for correct rendering. 