### PR TITLE
Removed redundancy in glossary.yaml

### DIFF
--- a/glossary.yaml
+++ b/glossary.yaml
@@ -92,8 +92,6 @@ terms:
     name: "Inline Action"
   - definition: "Deferred actions are actions sent to a peer action that are scheduled to run, at best, at a later time, at a block producer's discretion. There is no guarantee that a deferred action will be executed. From the perspective of the originating action, i.e., the action that creates the deferred action, it can only determine whether the create request was submitted successfully or whether it failed (if it fails, it will fail immediately). Deferred actions carry the authority of the contract that sends them. A deferred action can also be cancelled by another action."
     name: "Deferred Action"
-  - definition: "The chain state or database is a memory mapped file, storing the blockchain state of each block (account details, deferred transactions, transactions, data stored using multi index tables in smart contracts, etc.). Once a block becomes irreversible the chain state is not cached anymore."
-    name: "Chain State"
   - definition: "A private network is a production network, or a test network, to which access is private, that is, the API endpoints, and block producers connectivity URLs and IPs are private. Access to a private network is done via invitation, or, upon request to join, is granted by the owners of the private network."
     name: "Private Network"
   - definition: "A blockchain application is a software application that has integrated a blockchain in its architecture as the storage layer for part of, or, all of its data. This includes software applications that do not own their own contract on the blockchain and instead only interact with the system contracts of the blockchain."


### PR DESCRIPTION
Resolves #162 

The **Chain State** was defined twice. Removed one instance. 