### PR TITLE
getting started vs get started

### DIFF
--- a/docs/02_getting-started/01_try-eosio.md
+++ b/docs/02_getting-started/01_try-eosio.md
@@ -8,4 +8,4 @@ If you do not want to install `EOSIO` binaries on your local machine, or if you 
 You can give it a try in a matter of seconds [right now](https://gitpod.io/#https://github.com/EOSIO/eosio-web-ide) and you can read more details about it [on the eosio-web-ide project page](https://github.com/EOSIO/eosio-web-ide).
 
 ## What's Next?
-- [Getting Started](./02_development-environment/02_introduction.md): Install EOSIO in your local development environment.
+- [Get Started](./02_development-environment/02_introduction.md): Install EOSIO in your local development environment.

--- a/docs/02_getting-started/index.md
+++ b/docs/02_getting-started/index.md
@@ -1,4 +1,8 @@
-## Topics Covered in Getting Started
+---
+content_title: "Getting Started"
+link_text: "Get Started"
+---
+
 - Installing eosio.cdt
 - Using Keosd as a local development wallet
 - Starting the Nodeos daemon
@@ -10,5 +14,6 @@
 - Payable actions using EOSIO `notify` declarations
 
 ## What's next?
+
 - [Try EOSIO](./01_try-eosio.md): Try EOSIO in your browser with Gitpod.
-- [Getting Started](./02_development-environment/introduction.md): Install EOSIO in your local development environment.
+- [Get Started](./02_development-environment/introduction.md): Install EOSIO in your local development environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,6 @@ The transactions recorded on the blockchain form an immutable history of the blo
 `youtube: https://www.youtube.com/watch?v=MqSE5WLusko`
 
 ## What's Next?
-- [Getting Started](./02_getting-started/index.md): Learn how to develop on an EOSIO blockchain
+- [Get Started](./02_getting-started/index.md): Learn how to develop on an EOSIO blockchain
 - [Protocol](./04_protocol/index.md): Understand the protocols that makes up an EOSIO blockchain
 - [Get Involved](./get-involved/index.md): Learn how to get involved and contribute to the EOSIO ecosystem.


### PR DESCRIPTION
resolves #31 
the buttons/links/menu actions to be called "Get Started" and the title of the page where the button/link/menu action transfer the user to should be "Getting Started".