### PR TITLE
Fix a name typo in eosio.cdt installation tutorial

### DIFF
--- a/docs/02_getting-started/02_development-environment/04_install-the-CDT.md
+++ b/docs/02_getting-started/02_development-environment/04_install-the-CDT.md
@@ -25,7 +25,7 @@ brew remove eosio.cdt
 ```shell
 wget https://github.com/EOSIO/eosio.cdt/releases/download/v1.6.3/eosio.cdt_1.6.3-1-ubuntu-18.04_amd64.deb
 
-sudo apt install ./eosio.cdt_1.6.3-1_amd64.deb
+sudo apt install ./eosio.cdt_1.6.3-1-ubuntu-18.04_amd64.deb
 ```
 ## Uninstall
 ```shell


### PR DESCRIPTION
The file downloaded is named `eosio.cdt_1.6.3-1-ubuntu-18.04_amd64.deb` instead of `eosio.cdt_1.6.3-1_amd64.deb`.