### PR TITLE
Removed attribute to keep consistent wording

### DIFF
--- a/docs/02_getting-started/03_smart-contract-development/01_hello-world.md
+++ b/docs/02_getting-started/03_smart-contract-development/01_hello-world.md
@@ -59,7 +59,6 @@ class [[eosio::contract]] hello : public contract {
   public:
       using contract::contract;
 
-      [[eosio::action]]
       void hi( name user ) {
          print( "Hello, ", user);
       }


### PR DESCRIPTION
The C++11 style attribute was already added in the block above the "Add a C++11 style attribute above the action, this way the abi generator can produce more reliable output." paragraph, making the wording confusing, as both blocks of code are identical: nothing was added.
