### PR TITLE
Using type alias instead of typedef in the example code and improving the description

### DIFF
--- a/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
+++ b/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
@@ -2,7 +2,7 @@
 content_title: "2.4: Data Persistence"
 link_text: "2.4: Data Persistence"
 ---
-To learn about data persistence, write a simple smart contract that functions as an address book. While this use case isn't very practical as a production smart contract for various reasons, it's a good contract to start with to learn how data persistence works on EOSIO without being distracted by business logic that does not pertain to eosio's `multi_index` functionality.
+To learn about data persistence, we will write a simple smart contract that functions as an address book. While this use case is not very practical as a production smart contract for various reasons, it is a good contract to start with to learn how data persistence works on EOSIO without being distracted by business logic that does not pertain to eosio's `multi_index` functionality.
 ## Step 1: Create a new directory
 Earlier, you created a contract directory, navigate there now.
 
@@ -24,7 +24,7 @@ touch addressbook.cpp
 Open the file in your favorite editor.
 
 ## Step 3: Write an Extended Standard Class and Include EOSIO
-In a previous tutorial, you created a hello world contract and you learned the basics. You will be familiar with the structure below, the class has been named `addressbook` respectively.
+If you followed the previous tutorial, you created a hello world contract and learned the basics. We use a similiar structure below with the class named `addressbook`:
 
 ```cpp
 #include <eosio/eosio.hpp>
@@ -40,7 +40,7 @@ class [[eosio::contract("addressbook")]] addressbook : public eosio::contract {
 ```
 
 ## Step 4: Create The Data Structure for the Table
-Before a table can be configured and instantiated, a struct that represents the data structure of the address book needs to be written. Since it's an address book, the table will contain people, so create a `struct` called "person"
+Before a table can be configured and instantiated, we need to define a struct that represents the data structure of the address book. Since it is an address book, the table will contain people, so create a `struct` called "person"
 
 ```cpp
 struct person {};
@@ -92,7 +92,7 @@ struct person {
 Now that the data structure of the table has been defined with a `struct` we need to configure the table. The [eosio::multi_index](https://developers.eos.io/manuals/eosio.cdt/latest/classeosio_1_1multi__index) constructor needs to be named and configured to use the struct we previously defined.
 
 ```cpp
-typedef eosio::multi_index<"people"_n, person> address_index;
+using address_index = eosio::multi_index<"people"_n, person>;
 ```
 With the above `multi_index` configuration there is a table named **people**, that
 
@@ -123,8 +123,8 @@ class [[eosio::contract("addressbook")]] addressbook : public eosio::contract {
 
       uint64_t primary_key() const { return key.value;}
     };
-
-    typedef eosio::multi_index<"people"_n, person> address_index;
+    
+  using address_index = eosio::multi_index<"people"_n, person>;
 };
 ```
 
@@ -412,8 +412,7 @@ private:
     std::string state;
     uint64_t primary_key() const { return key.value; }
   };
-  typedef eosio::multi_index<"people"_n, person> address_index;
-
+  using address_index = eosio::multi_index<"people"_n, person>;
 };    
 ```
 

--- a/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
+++ b/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
@@ -2,7 +2,7 @@
 content_title: "2.4: Data Persistence"
 link_text: "2.4: Data Persistence"
 ---
-To learn about data persistence, we will write a simple smart contract that functions as an address book. While this use case is not very practical as a production smart contract for various reasons, it is a good contract to start with to learn how data persistence works on EOSIO without being distracted by business logic that does not pertain to eosio's `multi_index` functionality.
+To learn about data persistence, we will write a simple smart contract that functions as an address book. While this use case is not very practical as a production smart contract, it is a good contract to start with to learn how data persistence works on EOSIO without being distracted by business logic that does not pertain to eosio's `multi_index` functionality.
 ## Step 1: Create a new directory
 Earlier, you created a contract directory, navigate there now.
 
@@ -45,16 +45,16 @@ Before a table can be configured and instantiated, we need to define a struct th
 ```cpp
 struct person {};
 ```
-When defining the structure of a multi_index table, you will require a unique value to use as the primary key.
+When defining the structure of a multi_index table, you use a unique value as the primary key.
 
-For this contract, use a field called "key" with type `name`. This contract will have one unique entry per user, so this key will be a consistent and guaranteed unique value based on the user's `name`
+For this contract, use a field called "key" with type `name` based on the user's `name`. This contract has one unique entry per user, so this key will be a consistent and guaranteed unique value.
 
 ```cpp
 struct person {
  name key;
 };
 ```
-Since this contract is an address book it probably should store some relevant details for each entry or *person*
+Since this contract is an address book it should store some relevant details for each entry or *person*
 
 ```cpp
 struct person {
@@ -68,9 +68,9 @@ struct person {
 ```
 Great. The basic data structure is now complete.
 
-Next, define a `primary_key` method. Every multi_index struct requires a *primary key* to be set. Behind the scenes, this method is used according to the index specification of your multi_index instantiation. EOSIO wraps [boost::multi_index](https://www.boost.org/doc/libs/1_59_0/libs/multi_index/doc/index.html)
+Next, define a `primary_key` method. Every multi_index struct requires a *primary key* method. Behind the scenes, this method is used according to the index specification of your multi_index instantiation. EOSIO `multi_index` wraps [boost::multi_index](https://www.boost.org/doc/libs/1_59_0/libs/multi_index/doc/index.html)
 
-Create an method `primary_key()` and return a struct member, in this case, the `key` member as previously discussed.
+Create a method `primary_key()` and return a struct member, in this case, the `key` member as previously discussed.
 
 ```cpp
 struct person {
@@ -99,7 +99,6 @@ With the above `multi_index` configuration there is a table named **people**, th
 1. Uses the `_n` operator to define an eosio::name type and uses that to name the table. This table contains a number of different singular "persons", so name the table "people".
 2. Pass in the singular `person` struct defined in the previous step.
 3. Declare this table's type. This type will be used to instantiate this table later.
-4. There are some additional configurations, such as configuring indices, that will be covered further on.
 
 So far, our file should look like this.
 
@@ -140,13 +139,13 @@ addressbook(name receiver, name code, datastream<const char*> ds):contract(recei
 ```
 
 ## Step 7: Adding a record to the table
-Previously, the primary key of the multi-index table was defined to enforce that this contract will only store one record per user. To make it all work, some assumptions about the design need to be established.
+Previously, the primary key of the multi-index table was defined to enforce that this contract will only store one record per user. To make it all work, some rules about the design need to be established.
 
 1. The only account authorized to modify the address book is the user.
-2. the **primary_key** of our table is unique, based on username
+2. The **primary_key** of our table is unique, based on username
 3. For usability, the contract should have the ability to both create and modify a table row with a single action.
 
-In EOSIO a chain has unique accounts, so `name` is an ideal candidate as a **primary_key** in this specific use case. The [name](https://developers.eos.io/manuals/eosio.cdt/latest/structeosio_1_1name) type is a `uint64_t`.
+On a EOSIO blockchain an account name is unique, therefore the `name` type is an ideal candidate as a **primary_key**. Behind the scenes, the [name](https://developers.eos.io/manuals/eosio.cdt/latest/structeosio_1_1name) type is an `uint64_t` integer.
 
 Next, define an action for the user to add or update a record. This action will need to accept any values that this action needs to be able to emplace (create) or modify.
 

--- a/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
+++ b/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
@@ -324,7 +324,7 @@ The contract is now mostly complete. Users can create, modify and erase records.
 
 ## Step 9: Preparing for the ABI
 
-## 9.1 ABI Action Declarations
+### 9.1 ABI Action Declarations
 
 [eosio.cdt](https://developers.eos.io/manuals/eosio.cdt/latest) includes an ABI Generator, but for it to work will require some declarations.
 
@@ -335,7 +335,7 @@ Above both the `upsert` and `erase` functions add the following C++11 declaratio
 ```
 The above declaration will extract the arguments of the action and create necessary ABI *struct* descriptions in the generated ABI file.
 
-## 9.2 ABI Table Declarations
+### 9.2 ABI Table Declarations
 Add an ABI declaration to the table. Modify the following line defined in the private region of your contract:
 
 ```cpp

--- a/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
+++ b/docs/02_getting-started/03_smart-contract-development/04_data-persistence.md
@@ -2,7 +2,8 @@
 content_title: "2.4: Data Persistence"
 link_text: "2.4: Data Persistence"
 ---
-To learn about data persistence, we will write a simple smart contract that functions as an address book. While this use case is not very practical as a production smart contract, it is a good contract to start with to learn how data persistence works on EOSIO without being distracted by business logic that does not pertain to eosio's `multi_index` functionality.
+To learn about data persistence, you write a simple smart contract that functions as an address book. While this use case is not very practical as a production smart contract, it is a good contract to start with to learn how data persistence works on EOSIO without being distracted by business logic that does not pertain to eosio's `multi_index` functionality.
+
 ## Step 1: Create a new directory
 Earlier, you created a contract directory, navigate there now.
 
@@ -24,7 +25,7 @@ touch addressbook.cpp
 Open the file in your favorite editor.
 
 ## Step 3: Write an Extended Standard Class and Include EOSIO
-If you followed the previous tutorial, you created a hello world contract and learned the basics. We use a similiar structure below with the class named `addressbook`:
+If you followed the previous tutorial, you created a hello world contract and learned the basics. The code snippet uses a similiar structure with a class named `addressbook`:
 
 ```cpp
 #include <eosio/eosio.hpp>
@@ -68,7 +69,7 @@ struct person {
 ```
 Great. The basic data structure is now complete.
 
-Next, define a `primary_key` method. Every multi_index struct requires a *primary key* method. Behind the scenes, this method is used according to the index specification of your multi_index instantiation. EOSIO `multi_index` wraps [boost::multi_index](https://www.boost.org/doc/libs/1_59_0/libs/multi_index/doc/index.html)
+Next, define a `primary_key` method. Every `multi_index` struct requires a *primary key* method. Behind the scenes, this method is used according to the index specification of your `multi_index` instantiation. EOSIO `multi_index` wraps [boost::multi_index](https://www.boost.org/doc/libs/1_59_0/libs/multi_index/doc/index.html)
 
 Create a method `primary_key()` and return a struct member, in this case, the `key` member as previously discussed.
 

--- a/docs/02_getting-started/03_smart-contract-development/05_secondary-indices.md
+++ b/docs/02_getting-started/03_smart-contract-development/05_secondary-indices.md
@@ -32,9 +32,9 @@ uint64_t get_secondary_1() const { return age;}
 A field has been defined as the secondary index, next the  `address_index` table needs to be reconfigured.
 
 ```cpp
-typedef eosio::multi_index<"people"_n, person,
+using address_index = eosio::multi_index<"people"_n, person,
 indexed_by<"byage"_n, const_mem_fun<person, uint64_t, &person::get_secondary_1>>
-  > address_index;
+>;
 ```
 
 In the third parameter, we pass a `indexed_by` struct which is used to instantiate a index.
@@ -244,7 +244,7 @@ private:
 
   };
 
-  typedef eosio::multi_index<"people"_n, person, indexed_by<"byage"_n, const_mem_fun<person, uint64_t, &person::get_secondary_1>>> address_index;
+  using address_index = eosio::multi_index<"people"_n, person, indexed_by<"byage"_n, const_mem_fun<person, uint64_t, &person::get_secondary_1>>>;
 
 };
 ```

--- a/docs/02_getting-started/03_smart-contract-development/07_inline-action-to-external-contract.md
+++ b/docs/02_getting-started/03_smart-contract-development/07_inline-action-to-external-contract.md
@@ -394,7 +394,7 @@ public:
         }
       });
 
-      if(changes.length() > 0) {
+      if(!changes.empty()) {
         send_summary(user, " successfully modified record in addressbook. Fields changed: " + changes);
         increment_counter(user, "modify");
       } else {


### PR DESCRIPTION
* Using type alias instead of typedef
* Improving the description of paragraphs

Partially address #218 