### PR TITLE
Reposition Testnet QSG left menu and fix images folder - 2.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -38,7 +38,8 @@
       "options": {
         "docs_dir": "docs/08_testnet-quick-start-quide",
         "output_dir": "08_testnet-quick-start-quide",
-        "disable_readme_import": true
+        "disable_readme_import": true,
+        "exclude": ["images"]
       }
     },
     {


### PR DESCRIPTION
Resolves #281 and removes `images` sub-folder