### PR TITLE
Up-port of PRs 285, 290, 294 - develop

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -6,7 +6,7 @@
       "options": {
         "docs_dir": "docs",
         "disable_indices": true,
-        "exclude": ["get-involved", "05_community-developer-tools", "06_eosio-blockchain-networks", "07_tools"]
+        "exclude": ["get-involved", "05_community-developer-tools", "06_eosio-blockchain-networks", "07_tools", "08_testnet-quick-start-quide"]
       }
     },
     {
@@ -31,6 +31,14 @@
         "directory_source": "resource-directory.yaml",
         "directory_markdown_output": "resources",
         "directory_nav_parent": "Resources"
+      }
+    },
+    {
+      "name": "collate_markdown",
+      "options": {
+        "docs_dir": "docs/08_testnet-quick-start-quide",
+        "output_dir": "08_testnet-quick-start-quide",
+        "disable_readme_import": true
       }
     },
     {

--- a/docs.json
+++ b/docs.json
@@ -38,7 +38,8 @@
       "options": {
         "docs_dir": "docs/08_testnet-quick-start-quide",
         "output_dir": "08_testnet-quick-start-quide",
-        "disable_readme_import": true
+        "disable_readme_import": true,
+        "exclude": ["images"]
       }
     },
     {

--- a/docs.json
+++ b/docs.json
@@ -36,17 +36,19 @@
     {
       "name": "collate_markdown",
       "options": {
-        "docs_dir": "docs/08_testnet-quick-start-quide",
-        "output_dir": "08_testnet-quick-start-quide",
-        "exclude": ["images"]
+        "docs_dir": "docs/08_testnet-quick-start-guide",
+        "output_dir": "08_testnet-quick-start-guide",
+        "exclude": ["images"],
+        "disable_readme_import": true
       }
     },
     {
       "name": "collate_markdown",
       "options": {
-        "docs_dir": "docs/08_testnet-quick-start-quide/images",
-        "output_dir": "08_testnet-quick-start-quide/images",
-        "disable_summary_gen": true
+        "docs_dir": "docs/08_testnet-quick-start-guide/images",
+        "output_dir": "08_testnet-quick-start-guide/images",
+        "disable_summary_gen": true,
+        "disable_readme_import": true
       }
     },
     {

--- a/docs.json
+++ b/docs.json
@@ -38,8 +38,15 @@
       "options": {
         "docs_dir": "docs/08_testnet-quick-start-quide",
         "output_dir": "08_testnet-quick-start-quide",
-        "disable_readme_import": true,
         "exclude": ["images"]
+      }
+    },
+    {
+      "name": "collate_markdown",
+      "options": {
+        "docs_dir": "docs/08_testnet-quick-start-quide/images",
+        "output_dir": "08_testnet-quick-start-quide/images",
+        "disable_summary_gen": true
       }
     },
     {


### PR DESCRIPTION
Up-port of PRs #285, #290, #294 to `develop` (`docs.json` fixes).
Depends on commits from PRs #275, #280 to be cherry-picked to `develop` (Testnet QSG). @bobgt 