### PR TITLE
docs: updated tutorial code to match source files, and added tictacto…

### DIFF
--- a/docs/03_tutorials/20_tic-tac-toe-game-smart-contract-single-node.md
+++ b/docs/03_tutorials/20_tic-tac-toe-game-smart-contract-single-node.md
@@ -166,8 +166,15 @@ Wallets:
 cleos wallet import --name local 5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 ``` 
 
-Create two key pairs, one for each account.
+Create three key pairs, one for the smart contract, and two separate accounts for the host and the challenger.
 
+```shell
+cleos create key --to-console
+```
+```console
+Private key: 5JyC1kXq3WSpsyBc7rYpkBQBSc9GjLvVQ2QHFnS1iojiYNmKifX
+Public key: EOS7RGhr3mEvHm66Rter6vj8ZSGJ1uV8wZSEUuaeRj1Ywvi9YqFZn
+```
 ```shell
 cleos create key --to-console
 ```
@@ -181,6 +188,16 @@ cleos create key --to-console
 ```console
 Private key: 5JReVMTiiztAUyQGp9w7BMMm1HVUurDmEKuSL53DQww3JKVZjot
 Public key: EOS7qkiVnptc8wbHzHPC9jj1YECKJgQeUktBTm8RDA64oH3e75QW5
+```
+
+Create the tictactoe smart contract account.  
+```shell
+cleos create account eosio tictactoe EOS7RGhr3mEvHm66Rter6vj8ZSGJ1uV8wZSEUuaeRj1Ywvi9YqFZn
+```
+
+Import the matching private key to the local wallet
+```shell
+cleos wallet import --name local --private-key 5JyC1kXq3WSpsyBc7rYpkBQBSc9GjLvVQ2QHFnS1iojiYNmKifX
 ```
 
 Create the host account.  
@@ -202,9 +219,6 @@ Import the matching private key to the local wallet
 ```shell
 cleos wallet import --name local --private-key 5JReVMTiiztAUyQGp9w7BMMm1HVUurDmEKuSL53DQww3JKVZjot
 ```
-
-[[info]
-| You can also use three or more accounts, one for the smart contract and separate accounts for the host(s) and the challenger(s). 
 
 [[warning | Keep your keys safe]]
 | Use a wallet to securely store private keys. Keep your private keys private and do not share your private keys with anyone. A private key provides full access to a blockchain account.
@@ -306,7 +320,7 @@ using namespace eosio;
 
 ```c++
 // 7. Declare the class. 8. Use the [[eosio::contract(contract_name)]] attribute. 9. Inherit from the base class. 
-class[[eosio::contract("tictactoe")]] TicTacToe : public contract
+class[[eosio::contract("tictactoe")]] tictactoe : public contract
 {
 public:
     
@@ -314,7 +328,7 @@ public:
     using contract::contract;
     
     // 11. Use the base class constructor.
-    TicTacToe(name receiver, name code, datastream<const char *> ds) : contract(receiver, code, ds) {}
+    tictactoe(name receiver, name code, datastream<const char *> ds) : contract(receiver, code, ds) {}
 };
 ```
 9. Declare game data structure and use the `[[eosio::table]]` attribute to let the compiler know this uses a multi index table. Click on this link for more information on [generator attributes.](https://developers.eos.io/manuals/eosio.cdt/v1.7/best-practices/abi/abi-code-generator-attributes-explained) Click on this link for more information about [Multi Index Table](https://developers.eos.io/manuals/eosio.cdt/v1.7/group__multiindex)
@@ -602,7 +616,7 @@ void tictactoe::move(const name &challenger, const name &host, const name &by, c
     check(by == itr->turn, "it's not your turn yet!");
 
     // Check if user makes a valid movement
-    check(IsValidMove(row, column, itr->board), "Not a valid movement.");
+    check(isValidMove(row, column, itr->board), "Not a valid movement.");
 
     // Fill the cell, 1 for host, 2 for challenger
     //TODO could use constant for 1 and 2 as well
@@ -611,7 +625,7 @@ void tictactoe::move(const name &challenger, const name &host, const name &by, c
     existingHostGames.modify(itr, itr->host, [&](auto &g) {
         g.board[row * game::boardWidth + column] = cellValue;
         g.turn = turn;
-        g.winner = GetWinner(g);
+        g.winner = getWinner(g);
     });
 }
 ```
@@ -651,7 +665,7 @@ The tictactoe directory now contains two new files, `tictactoe.wasm` and `tictac
 
 In the same directory as the generated `wasm` and `ABI` files run
 ```shell
-cleos set contract host ./ tictactoe.wasm tictactoe.abi -p host@active
+cleos set contract tictactoe ./ tictactoe.wasm tictactoe.abi -p tictactoe@active
 ```
 
 ## Play The Game

--- a/docs/03_tutorials/20_tic-tac-toe-game-smart-contract-single-node.md
+++ b/docs/03_tutorials/20_tic-tac-toe-game-smart-contract-single-node.md
@@ -520,7 +520,7 @@ bool tictactoe::isEmptyCell(const uint8_t &cell){
 ```c++
 bool tictactoe::isValidMove(const uint16_t &row, const uint16_t &column, const std::vector<uint8_t> &board){
     uint32_t movementLocation = row * game::boardWidth + column;
-    bool isValid = movementLocation < board.size() && IsEmptyCell(board[movementLocation]);
+    bool isValid = movementLocation < board.size() && isEmptyCell(board[movementLocation]);
     return isValid;
 }
 ```
@@ -544,7 +544,7 @@ name tictactoe::getWinner(const game &currentGame)
 
     for (uint32_t i = 0; i < board.size(); i++)
     {
-        isBoardFull &= IsEmptyCell(board[i]);
+        isBoardFull &= isEmptyCell(board[i]);
         uint16_t row = uint16_t(i / game::boardWidth);
         uint16_t column = uint16_t(i % game::boardWidth);
 

--- a/docs/03_tutorials/21_tic-tac-toe-game-smart-contract-Testnet.md
+++ b/docs/03_tutorials/21_tic-tac-toe-game-smart-contract-Testnet.md
@@ -205,7 +205,7 @@ using namespace eosio;
 
 ```c++
 // 7. Declare the class. 8. Use the [[eosio::contract(contract_name)]] attribute. 9. Inherit from the base class. 
-class[[eosio::contract("tictactoe")]] TicTacToe : public contract
+class[[eosio::contract("tictactoe")]] tictactoe : public contract
 {
 public:
     
@@ -213,7 +213,7 @@ public:
     using contract::contract;
     
     // 11. Use the base class constructor.
-    TicTacToe(name receiver, name code, datastream<const char *> ds) : contract(receiver, code, ds) {}
+    tictactoe(name receiver, name code, datastream<const char *> ds) : contract(receiver, code, ds) {}
 };
 ```
 9. Declare game data structure and use the `[[eosio::table]]` attribute to let the compiler know this uses a multi index table. Click on this link for more information on [generator attributes.](https://developers.eos.io/manuals/eosio.cdt/v1.7/best-practices/abi/abi-code-generator-attributes-explained) Click on this link for more information about [Multi Index Table](https://developers.eos.io/manuals/eosio.cdt/v1.7/group__multiindex)
@@ -501,7 +501,7 @@ void tictactoe::move(const name &challenger, const name &host, const name &by, c
     check(by == itr->turn, "it's not your turn yet!");
 
     // Check if user makes a valid movement
-    check(IsValidMove(row, column, itr->board), "Not a valid movement.");
+    check(isValidMove(row, column, itr->board), "Not a valid movement.");
 
     // Fill the cell, 1 for host, 2 for challenger
     //TODO could use constant for 1 and 2 as well
@@ -510,7 +510,7 @@ void tictactoe::move(const name &challenger, const name &host, const name &by, c
     existingHostGames.modify(itr, itr->host, [&](auto &g) {
         g.board[row * game::boardWidth + column] = cellValue;
         g.turn = turn;
-        g.winner = GetWinner(g);
+        g.winner = getWinner(g);
     });
 }
 ```

--- a/docs/03_tutorials/21_tic-tac-toe-game-smart-contract-Testnet.md
+++ b/docs/03_tutorials/21_tic-tac-toe-game-smart-contract-Testnet.md
@@ -405,7 +405,7 @@ bool tictactoe::isEmptyCell(const uint8_t &cell){
 ```c++
 bool tictactoe::isValidMove(const uint16_t &row, const uint16_t &column, const std::vector<uint8_t> &board){
     uint32_t movementLocation = row * game::boardWidth + column;
-    bool isValid = movementLocation < board.size() && IsEmptyCell(board[movementLocation]);
+    bool isValid = movementLocation < board.size() && isEmptyCell(board[movementLocation]);
     return isValid;
 }
 ```
@@ -429,7 +429,7 @@ name tictactoe::getWinner(const game &currentGame)
 
     for (uint32_t i = 0; i < board.size(); i++)
     {
-        isBoardFull &= IsEmptyCell(board[i]);
+        isBoardFull &= isEmptyCell(board[i]);
         uint16_t row = uint16_t(i / game::boardWidth);
         uint16_t column = uint16_t(i % game::boardWidth);
 


### PR DESCRIPTION
Thanks for the tutorials!

A couple of revisions to the tictactoe tutorial.

1. **Adding the creation of smart contract account `tictactoe`.**
   In this [tutorial](https://developers.eos.io/welcome/latest/tutorials/tic-tac-toe-game-smart-contract-single-node), the latter cleos commands assume that the developer has deployed the smart contract under the account `tictactoe`. But, the preceding section instructs the developer to deploy the smart constract under the account of `host`. To lessen the confusion, I've added another create account section for `tictactoe` smart contract, and updated the relevant contract deployment to be under `tictactoe`.
  This should also address #305.

2. **Updated sample code on the doc**
   In both tutorials for Single Node and Testnet, the code samples for `tictactoe.hpp` has the class name and the constructor as `TicTacToe`. But the header file follows the naming of `tictactoe`. To address this issue, the in the code samples, the class name and the constructor was updated from `TicTacToe` -> `tictactoe`, as per reference [here](https://github.com/EOSIO/welcome/blob/release/2.0.x/src/tictactoe/tictactoe.cpp). In addition, addressed some changes mentioned in #308.

@halsaphi, would like to get some feedback on 1. since I don't want the revisions to deviate from the original direction you were planning for the tutorial. Thanks!
   
