### PR TITLE
fix cases in docs.json - they should be consistent

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -13,7 +13,7 @@
       "name": "directory",
       "options": {
         "directory_source": "manuals-directory.yaml",
-        "directory_markdown_output": "Manuals",
+        "directory_markdown_output": "manuals",
         "directory_nav_parent": "Manuals"
       }
     },
@@ -21,7 +21,7 @@
       "name": "directory",
       "options": {
         "directory_source": "reference-directory.yaml",
-        "directory_markdown_output": "Reference",
+        "directory_markdown_output": "reference",
         "directory_nav_parent": "API Reference"
       }
     },


### PR DESCRIPTION
Fixing a case problem for manuals and reference dirs. Upper case create new dirs Manuals and Reference in addition to manuals and reference. This later causes lots of problems with links and versions. 