### PR TITLE
docs 2.0.x fix link in tic tac toe

### DIFF
--- a/docs/80_tutorials/20_tic-tac-toe-game-smart-contract-single-node.md
+++ b/docs/80_tutorials/20_tic-tac-toe-game-smart-contract-single-node.md
@@ -656,7 +656,7 @@ Warning, action <close> does not have a ricardian contract
 Warning, action <move> does not have a ricardian contract
 ```
 
-For this tutorial we ignore these warnings. Click on the following link for a tutorial showing how to add the optional ricardian contracts [Prepare the Ricardian Contract](../02_getting-started/03_smart-contract-development/04_data-persistence.md#step-10-prepare-the-ricardian-contract-optional "Getting Started - Data Peristence")
+For this tutorial we ignore these warnings. Click on the following link for a tutorial showing how to add the optional ricardian contracts [Prepare the Ricardian Contract](../smart-contract-guides/data-persistence/#step-10-prepare-the-ricardian-contract-optional)
 
 The tictactoe directory now contains two new files, `tictactoe.wasm` and `tictactoe.abi`.
 


### PR DESCRIPTION
docs 2.0.x fix link in tic tac toe

fixes #430 

the same link is correct in release 2.1.x