### PR TITLE
Add new return-values and key-values examples

### DIFF
--- a/manuals-directory.yaml
+++ b/manuals-directory.yaml
@@ -43,6 +43,10 @@ sections:
         description: An example application for developers to use the EOSIO action return values feature with eosjs. Powered by Gitpod.io and Docker.
         link: https://github.com/EOSIO/return-values-example-app
 
+      - title: key-value-example-app
+        description: An example application for developers to use the EOSIO key value database feature with eosjs. Powered by Gitpod.io and Docker.
+        link: https://github.com/EOSIO/key-value-example-app
+
   - title: Tools
     listings:
       - title: eosio-explorer

--- a/manuals-directory.yaml
+++ b/manuals-directory.yaml
@@ -39,6 +39,10 @@ sections:
         description: An example for developers showing an application built on EOSIO combining UAL, Manifest Spec, and Ricardian Contracts
         link: https://github.com/EOSIO/tropical-example-web-app
 
+      - title: return-values-example-app
+        description: An example application for developers to use the EOSIO action return values feature with eosjs. Powered by Gitpod.io and Docker.
+        link: https://github.com/EOSIO/return-values-example-app
+
   - title: Tools
     listings:
       - title: eosio-explorer


### PR DESCRIPTION
Resolves devrel-1524

Add new stable releases of the following examples:

- https://github.com/EOSIO/return-values-example-app
- https://github.com/EOSIO/key-value-example-app

To the manuals directory in dev portal under Examples:

- https://developers.eos.io/welcome/latest/manuals/index

