### PR TITLE
fix dead link for boost download & clearify wording

### DIFF
--- a/docs/07_tools/01_history-tools/build-ubuntu-1804.md
+++ b/docs/07_tools/01_history-tools/build-ubuntu-1804.md
@@ -50,15 +50,15 @@ happen if you don't have enough RAM for the number of cores you use:
 
 ```
 cd ~
-wget https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.gz
+wget https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.gz
 tar xf boost_1_70_0.tar.gz
 cd boost_1_70_0
 ./bootstrap.sh
 ./b2 toolset=clang -j10 install
 ```
 
-Build and install CMake 3.14.5. Adjust `--parallel=` and `-j` to match your machine.
-Bad things will happen if you don't have enough RAM for the number of cores you use:
+Build and install CMake 3.14.5. Adjust `--parallel=` and `-j` to match your machine cores.
+Bad things will happen if you don't have enough RAM for the number of cores you use (see https://www.boost.org/doc/libs/1_70_0/tools/build/doc/html/index.html ):
 
 ```
 cd ~


### PR DESCRIPTION
https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.gz is a dead link; new url: https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.gz

Added the word 'cores' to make it clearer what the j flag does and added a link to the documentation for Boost.